### PR TITLE
fix(handlers.ts): fix anchor element creation

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -65,7 +65,9 @@ const anchorElement = (
   element: HTMLAnchorElement,
 ) => {
   const content = node.children.at(0)?.text
-  content && (element.href = content)
+  const url = node.url
+  content && (element.textContent = content)
+  url && (element.href = url)
 }
 
 /**


### PR DESCRIPTION
This change extracts the appropriate properties of the slate leaf node and properly sets the anchor element's textContent and href attributes, resulting properly formed anchor elements that can be converted into lexical link nodes.